### PR TITLE
Custom recaptcha branding

### DIFF
--- a/src/components/RecaptchaBranding/RecaptchaBranding.stories.tsx
+++ b/src/components/RecaptchaBranding/RecaptchaBranding.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import RecaptchaBranding from './RecaptchaBranding';
+
+const Meta: ComponentMeta<typeof RecaptchaBranding> = {
+  title: 'Components / RecaptchaBranding',
+  component: RecaptchaBranding,
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    scale: {
+      type: 'number'
+    }
+  }
+};
+
+const Template: ComponentStory<typeof RecaptchaBranding> = (args) => <RecaptchaBranding />;
+
+export const _RecaptchaBranding = Template.bind({});
+
+export default Meta;

--- a/src/components/RecaptchaBranding/RecaptchaBranding.tsx
+++ b/src/components/RecaptchaBranding/RecaptchaBranding.tsx
@@ -1,0 +1,27 @@
+export const RecaptchaBranding = () => {
+  return (
+    <div className="text-sm font-medium text-gray-400">
+      This site is protected by reCAPTCHA and the Google{' '}
+      <a
+        className="text-indigo-400 hover:text-indigo-400"
+        href="https://policies.google.com/privacy"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Privacy Policy
+      </a>{' '}
+      and{' '}
+      <a
+        className="text-indigo-400 hover:text-indigo-400"
+        href="https://policies.google.com/terms"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Terms of Service
+      </a>{' '}
+      apply.
+    </div>
+  );
+};
+
+export default RecaptchaBranding;

--- a/src/features/Auth/AuthCreateAccount/AuthCreateAccount.tsx
+++ b/src/features/Auth/AuthCreateAccount/AuthCreateAccount.tsx
@@ -3,6 +3,7 @@ import Alert from 'components/Alert/Alert';
 import Button from 'components/Button/Button';
 import Captcha from 'components/Captcha';
 import FormInput from 'components/Form/Input/Input';
+import RecaptchaBranding from 'components/RecaptchaBranding/RecaptchaBranding';
 import { siteLogo } from 'config';
 import { signIn } from 'next-auth/react';
 import { useCallback, useEffect, useRef } from 'react';
@@ -142,6 +143,8 @@ export const AuthCreateAccount = ({ callbackUrl, signIn }: AuthCreateAccountProp
                 Sign up
               </Button>
             </div>
+
+            <RecaptchaBranding />
           </form>
 
           <div className="mt-6">

--- a/src/features/Auth/AuthRecoverPassword/AuthRecoverPassword.tsx
+++ b/src/features/Auth/AuthRecoverPassword/AuthRecoverPassword.tsx
@@ -3,6 +3,7 @@ import Alert from 'components/Alert/Alert';
 import Button from 'components/Button/Button';
 import Captcha from 'components/Captcha';
 import FormInput from 'components/Form/Input/Input';
+import RecaptchaBranding from 'components/RecaptchaBranding/RecaptchaBranding';
 import { siteLogo } from 'config';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
@@ -92,6 +93,7 @@ export const AuthRecoverPassword = ({ callbackUrl }: AuthRecoverPasswordProps) =
                     Reset password
                   </Button>
                 </div>
+                <RecaptchaBranding />
               </>
             )}
           </form>

--- a/src/features/Footer/Newsletter/Newsletter.tsx
+++ b/src/features/Footer/Newsletter/Newsletter.tsx
@@ -2,6 +2,7 @@ import { ApolloError, useMutation } from '@apollo/client';
 import Alert from 'components/Alert/Alert';
 import Button from 'components/Button/Button';
 import Captcha from 'components/Captcha';
+import RecaptchaBranding from 'components/RecaptchaBranding/RecaptchaBranding';
 import { defaultKlaviyoListId } from 'config';
 import { useCallback, useState } from 'react';
 import { Klaviyo_AddMembersResponse } from 'types/takeshape';
@@ -76,6 +77,9 @@ export const Newsletter = (props: React.PropsWithChildren<NewsletterProps>) => {
           </Button>
         </div>
       </form>
+      <div className="mt-4">
+        <RecaptchaBranding />
+      </div>
       {feedback && (
         <div className="mt-2">
           <Alert status={feedback.type} primaryText={feedback.message} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -36,3 +36,9 @@
     @apply text-base text-gray-900 mt-4;
   }
 }
+
+/*
+* Hide reCAPTCHA badge
+ * https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+ */
+.grecaptcha-badge { visibility: hidden; }


### PR DESCRIPTION
### Screenshots

![Screen_Shot_2022-06-22_at_11_51_20_AM](https://user-images.githubusercontent.com/211047/175114315-576c039d-c664-4543-abcb-1a232c7f0235.png)

![Screen_Shot_2022-06-22_at_11_51_25_AM](https://user-images.githubusercontent.com/211047/175114357-aac79544-45cc-43ca-a69a-94e3a978d7e4.png)

![Screen_Shot_2022-06-22_at_11_51_11_AM](https://user-images.githubusercontent.com/211047/175114289-b694f0ae-df35-4c99-9279-9bf4ef6621c2.png)

### Test Plan (Steps to test):

1. Check that the fixed position recaptcha badge does not appear in the lower-right as it did previously
1. Check that the custom recaptcha branding appears on the create account, reset password, and footer newsletter forms

### Checklist:

- [x] Create a Test Plan
- [x] Changes Communicated (in commits or above)
- [x] ~Docs Updated~
- [x] Storybook Updated