### PR TITLE
Fix phone number validation

### DIFF
--- a/src/components/Form/CardPanel/CardPanelActions.tsx
+++ b/src/components/Form/CardPanel/CardPanelActions.tsx
@@ -27,7 +27,7 @@ export const FormCardPanelActions = ({
         {isSubmitting && !error && (
           <div className="inline-flex justify-center py-2 px-4 text-sm font-medium text-gray-500">Saving...</div>
         )}
-        {error && !isSubmitting && !isSubmitSuccessful && (
+        {error && !isSubmitting && (
           <div className="inline-flex justify-center py-2 px-4 text-sm font-medium text-red-800">[Error] {error}</div>
         )}
         <Button disabled={!isReady || isSubmitting || !isValid} color="primary" type="submit" size="medium">

--- a/src/components/Form/PhoneInput/PhoneInput.tsx
+++ b/src/components/Form/PhoneInput/PhoneInput.tsx
@@ -32,7 +32,7 @@ export const FormPhoneInput = ({
 }: FormPhoneInputProps & UseControllerProps<any, any>) => {
   rules = {
     ...rules,
-    validate: isPossiblePhoneNumber
+    validate: (value) => (value ? isPossiblePhoneNumber(`${value}`) : true)
   };
 
   const { field, fieldState } = useController({ name, control, defaultValue, rules, shouldUnregister });


### PR DESCRIPTION
### Test Plan (Steps to test):

1. Log in and go to your user profile
1. Make sure you get a client validation error if you try to save an invalid phone number like `911`
1. Make sure you get a server validation error (right away, not after a 5s delay) if you try to save a phone number that the client accepts but the server rejects, like `222 333 4444`
1. Make sure you can save a valid phone number
1. Make sure you can empty the phone number field and save since it's an optional field

### Checklist:

- [x] Create a Test Plan
- [x] Changes Communicated (in commits or above)
- [x] ~Docs Updated~
- [x] ~Storybook Updated~