### PR TITLE
Fix browser back button on collection pages

### DIFF
--- a/src/features/ProductCategory/ProductCategoryWithCollection.tsx
+++ b/src/features/ProductCategory/ProductCategoryWithCollection.tsx
@@ -1,7 +1,7 @@
 import { useLazyQuery } from '@apollo/client';
 import Seo from 'components/Seo';
+import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { pushState } from 'utils/history';
 import { ProductCategory } from './ProductCategory';
 import {
   ProductCategoryShopifyCollectionArgs,
@@ -20,6 +20,8 @@ export interface ProductCategoryWithCollectionProps {
 
 export const ProductCategoryWithCollection = ({ collection, pageSize, page }: ProductCategoryWithCollectionProps) => {
   pageSize = pageSize ?? 5;
+
+  const router = useRouter();
 
   const [currentPage, setCurrentPage] = useState(page ?? 1);
   const [requestPage, setRequestPage] = useState(null);
@@ -115,12 +117,16 @@ export const ProductCategoryWithCollection = ({ collection, pageSize, page }: Pr
   useEffect(() => {
     const pageCollection = loadedPages.current.get(currentPage);
     if (pageCollection) {
-      setCurrentCollection(pageCollection);
-      setCurrentTitle(getCurrentTitle(pageCollection, currentPage));
-      pushState(getCurrentUrl(pageCollection, currentPage));
-      window.scrollTo(0, 0);
+      const routerPath = router.asPath;
+      const currentUrl = getCurrentUrl(pageCollection, currentPage);
+      if (routerPath !== currentUrl) {
+        setCurrentCollection(pageCollection);
+        setCurrentTitle(getCurrentTitle(pageCollection, currentPage));
+        router.push(currentUrl);
+        window.scrollTo(0, 0);
+      }
     }
-  }, [currentPage]);
+  }, [currentPage, router]);
 
   // Handle page change requests
   const handleSetCurrentPage = useCallback(


### PR DESCRIPTION
### Test Plan (Steps to test):

1. Navigate to https://deluxe-sample-project-git-sc-9311-bugbrowser-b-77eb88-takeshape.vercel.app/collection/men then press next in the app then back in your browser. Verify you're on the first page
1. Navigate to https://deluxe-sample-project-git-sc-9311-bugbrowser-b-77eb88-takeshape.vercel.app/collection/men/eyJsYXN0X2lkIjo2ODYzMzk4OTI4NDg0LCJsYXN0X3ZhbHVlIjoiMCJ9/2 then press previous in the app then back in your browser. Verify you're on the second page.
1. Load any collections page, click through to a product then hit the browser back button. You should be back on the page you were at.
1. Load any collections page, then use next/previous in the app, then click through to a product then hit the browser back button. You should be back on the page you were at.

### Checklist:

- [x] Create a Test Plan
- [x] Changes Communicated (in commits or above)
- [x] ~Docs Updated~
- [x] ~Storybook Updated~