### PR TITLE
Make currency selection optional

### DIFF
--- a/.takeshape/pattern/schema.json
+++ b/.takeshape/pattern/schema.json
@@ -390,6 +390,9 @@
           "message": {
             "widget": "wysiwygSingleLineText"
           },
+          "showCurrencySelect": {
+            "widget": "toggleSwitch"
+          },
           "links": {
             "widget": "object",
             "properties": {
@@ -492,6 +495,7 @@
         },
         "order": [
           "message",
+          "showCurrencySelect",
           "links"
         ]
       }
@@ -4637,6 +4641,14 @@
             "description": "",
             "title": "Message",
             "@mapping": "takeshape:local:Navigation.PL-G7Y5Vx"
+          },
+          "showCurrencySelect": {
+            "type": "boolean",
+            "default": false,
+            "@l10n": false,
+            "description": "",
+            "title": "Show Currency Select",
+            "@mapping": "takeshape:local:Navigation.4bJEYLxFw"
           },
           "links": {
             "title": "Links",

--- a/src/features/Navigation/Navigation.stories.tsx
+++ b/src/features/Navigation/Navigation.stories.tsx
@@ -41,7 +41,8 @@ export const _Navigation = Template.bind({});
 _Navigation.args = {
   message: navigation.message,
   links: navigation.links,
-  currencies: navigation.currencies
+  currencies: navigation.currencies,
+  showCurrencySelect: true
 };
 
 export default Meta;

--- a/src/features/Navigation/Navigation.tsx
+++ b/src/features/Navigation/Navigation.tsx
@@ -5,12 +5,17 @@ import { Navigation as NavigationType } from './types';
 
 export interface NavigationProps extends NavigationType {}
 
-export const Navigation = ({ message, links, currencies }) => {
+export const Navigation = ({ message, links, currencies, showCurrencySelect }) => {
   return (
     <Fragment>
       <NavigationMobileMenu links={links} currencies={currencies} />
       <header className="relative z-10">
-        <NavigationTop message={message} links={links} currencies={currencies} />
+        <NavigationTop
+          message={message}
+          links={links}
+          currencies={currencies}
+          showCurrencySelect={showCurrencySelect}
+        />
       </header>
     </Fragment>
   );

--- a/src/features/Navigation/NavigationTop/NavigationTop.stories.tsx
+++ b/src/features/Navigation/NavigationTop/NavigationTop.stories.tsx
@@ -5,6 +5,7 @@ import { navigationResponse } from '../queries.fixtures';
 import { getNavigation } from '../transforms';
 import { NavigationTop } from './NavigationTop';
 
+export default { component: NavigationTop };
 const navigation = getNavigation(navigationResponse);
 
 const Meta: ComponentMeta<typeof NavigationTop> = {
@@ -41,7 +42,8 @@ export const _Mobile = Template.bind({});
 _Mobile.args = {
   message: navigation.message,
   links: navigation.links,
-  currencies: navigation.currencies
+  currencies: navigation.currencies,
+  showCurrencySelect: true
 };
 _Mobile.parameters = {
   viewport: {
@@ -53,7 +55,8 @@ export const _Tablet = Template.bind({});
 _Tablet.args = {
   message: navigation.message,
   links: navigation.links,
-  currencies: navigation.currencies
+  currencies: navigation.currencies,
+  showCurrencySelect: true
 };
 _Tablet.parameters = {
   viewport: {
@@ -65,8 +68,7 @@ export const _Desktop = Template.bind({});
 _Desktop.args = {
   message: navigation.message,
   links: navigation.links,
-  currencies: navigation.currencies
+  currencies: navigation.currencies,
+  showCurrencySelect: true
 };
 _Desktop.parameters = {};
-
-export default Meta;

--- a/src/features/Navigation/NavigationTop/NavigationTop.tsx
+++ b/src/features/Navigation/NavigationTop/NavigationTop.tsx
@@ -12,7 +12,7 @@ import { TopMessage } from './components/TopMessage';
 
 export interface NavigationTopProps extends Navigation {}
 
-export const NavigationTop = ({ message, links, currencies }: NavigationTopProps) => {
+export const NavigationTop = ({ message, links, currencies, showCurrencySelect }: NavigationTopProps) => {
   const setIsMobileMenuOpen = useSetAtom(isMobileMenuOpenAtom);
   const setIsSearchOpen = useSetAtom(isSearchOpenAtom);
 
@@ -28,31 +28,33 @@ export const NavigationTop = ({ message, links, currencies }: NavigationTopProps
           <div className="max-w-7xl mx-auto h-10 px-4 flex items-center justify-between sm:px-6 lg:px-8">
             {/* Currency selector */}
             <form className="hidden lg:block lg:flex-1">
-              <div className="flex">
-                <label htmlFor="desktop-currency" className="sr-only">
-                  Currency
-                </label>
-                <div className="-ml-2 group relative bg-gray-900 border-transparent rounded-md focus-within:ring-2 focus-within:ring-white">
-                  <TopCurrencySelect currencies={currencies} />
-                  <div className="absolute right-0 inset-y-0 flex items-center pointer-events-none">
-                    <svg
-                      aria-hidden="true"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 20 20"
-                      className="w-5 h-5 text-gray-300"
-                    >
-                      <path
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1.5"
-                        d="M6 8l4 4 4-4"
-                      />
-                    </svg>
+              {showCurrencySelect && (
+                <div className="flex">
+                  <label htmlFor="desktop-currency" className="sr-only">
+                    Currency
+                  </label>
+                  <div className="-ml-2 group relative bg-gray-900 border-transparent rounded-md focus-within:ring-2 focus-within:ring-white">
+                    <TopCurrencySelect currencies={currencies} />
+                    <div className="absolute right-0 inset-y-0 flex items-center pointer-events-none">
+                      <svg
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 20 20"
+                        className="w-5 h-5 text-gray-300"
+                      >
+                        <path
+                          stroke="currentColor"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="1.5"
+                          d="M6 8l4 4 4-4"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </div>
-              </div>
+              )}
             </form>
 
             <TopMessage message={message} />

--- a/src/features/Navigation/queries.ts
+++ b/src/features/Navigation/queries.ts
@@ -35,6 +35,7 @@ export const NavigationQuery = gql`
         }
       }
       messageHtml
+      showCurrencySelect
     }
   }
 `;

--- a/src/features/Navigation/transforms.ts
+++ b/src/features/Navigation/transforms.ts
@@ -12,6 +12,7 @@ export function getNavigation(response: NavigationResponse): Navigation {
   return {
     message: navigation.messageHtml.replace(/<\/?p>/g, ''),
     links: navigation.links,
-    currencies: [...currencyList]
+    currencies: [...currencyList],
+    showCurrencySelect: navigation.showCurrencySelect
   };
 }

--- a/src/features/Navigation/types.ts
+++ b/src/features/Navigation/types.ts
@@ -27,4 +27,5 @@ export type Navigation = {
   message: NavigationMessage;
   links: NavigationLinks;
   currencies: NavigationCurrency[];
+  showCurrencySelect: boolean;
 };

--- a/src/types/takeshape.ts
+++ b/src/types/takeshape.ts
@@ -13331,6 +13331,7 @@ export type Navigation = TsSearchable & {
   __typename?: 'Navigation';
   message?: Maybe<Scalars['JSON']>;
   messageHtml?: Maybe<Scalars['String']>;
+  showCurrencySelect?: Maybe<Scalars['Boolean']>;
   links?: Maybe<NavigationLinks>;
   _shapeId?: Maybe<Scalars['String']>;
   _id?: Maybe<Scalars['ID']>;
@@ -16545,6 +16546,7 @@ export type TsWhereInput = {
   Product_details?: InputMaybe<TsWhereProductPageDetailsRelationshipInput>;
   shopifyProductId?: InputMaybe<TsWhereStringInput>;
   message?: InputMaybe<TsWhereDraftjsInput>;
+  showCurrencySelect?: InputMaybe<TsWhereBooleanInput>;
   links?: InputMaybe<TsWhereNavigationLinksInput>;
   breadcrumbTitle?: InputMaybe<TsWhereStringInput>;
   parent?: InputMaybe<TsWhereCollectionRelationshipInput>;
@@ -20669,6 +20671,7 @@ export type UpdateNavigationResult = {
 /** update Navigation input */
 export type UpdateNavigationInput = {
   message?: InputMaybe<Scalars['JSON']>;
+  showCurrencySelect?: InputMaybe<Scalars['Boolean']>;
   links?: InputMaybe<NavigationLinksInput>;
   _shapeId?: InputMaybe<Scalars['String']>;
   _id?: InputMaybe<Scalars['ID']>;

--- a/takeshape-project.graphql
+++ b/takeshape-project.graphql
@@ -16333,6 +16333,9 @@ type Navigation implements TSSearchable {
   ): String
 
   """"""
+  showCurrencySelect: Boolean
+
+  """"""
   links: NavigationLinks
   _shapeId: String
   _id: ID
@@ -20537,6 +20540,7 @@ input TSWhereInput {
   Product_details: TSWhereProductPageDetailsRelationshipInput
   shopifyProductId: TSWhereStringInput
   message: TSWhereDraftjsInput
+  showCurrencySelect: TSWhereBooleanInput
   links: TSWhereNavigationLinksInput
   breadcrumbTitle: TSWhereStringInput
   parent: TSWhereCollectionRelationshipInput
@@ -24916,6 +24920,9 @@ type UpdateNavigationResult {
 input UpdateNavigationInput {
   """"""
   message: JSON
+
+  """"""
+  showCurrencySelect: Boolean
 
   """"""
   links: NavigationLinksInput


### PR DESCRIPTION
### Screenshots

![Screen Shot 2022-06-24 at 3 24 25 PM](https://user-images.githubusercontent.com/211047/175705907-9f388d27-ba1c-4438-b77c-fdfaf8f68194.png)

### Test Plan (Steps to test):

1. Make sure the currency selector is still there since it is enabled https://deluxe-sample-project-git-sc-9303-featuremake-1e48da-takeshape.vercel.app/
1. You can enable/disable it in the Navigation shape now: https://app.takeshape.io/project/06ccc3dc-a9da-4f5b-9142-5a104db52ee3/data/Navigation/edit (needs a site rebuild to see changes)

### Checklist:

- [x] Create a Test Plan
- [x] Changes Communicated (in commits or above)
- [x] ~Docs Updated~
- [x] ~Storybook Updated~