### PR TITLE
Rewards page api error ui

### DIFF
--- a/src/pages/account/rewards.tsx
+++ b/src/pages/account/rewards.tsx
@@ -1,3 +1,5 @@
+import { ErrorMessage } from 'components/Error/ErrorMessage';
+import Wrapper from 'components/Wrapper/Content';
 import { AccountLoyaltyCard } from 'features/AccountLoyaltyCard/AccountLoyaltyCard';
 import { GetMyLoyaltyCardQuery } from 'features/AccountLoyaltyCard/queries';
 import { getLoyaltyCard } from 'features/AccountLoyaltyCard/transforms';
@@ -9,10 +11,20 @@ import { GetMyLoyaltyCardQueryResponse } from 'types/takeshape';
 import { useAuthenticatedQuery } from 'utils/takeshape';
 
 const AccountRewardsPage: NextPage = () => {
-  const { transformedData: loyaltyCard } = useAuthenticatedQuery<GetMyLoyaltyCardQueryResponse, {}, LoyaltyCard>(
+  const { transformedData: loyaltyCard, error } = useAuthenticatedQuery<GetMyLoyaltyCardQueryResponse, {}, LoyaltyCard>(
     GetMyLoyaltyCardQuery,
     { transform: { data: getLoyaltyCard } }
   );
+
+  if (error) {
+    return (
+      <Layout seo={{ title: 'Rewards' }}>
+        <Wrapper>
+          <ErrorMessage headline="API error" subhead="Could not fetch rewards" body="" />
+        </Wrapper>
+      </Layout>
+    );
+  }
 
   if (!loyaltyCard) {
     return null;
@@ -21,7 +33,7 @@ const AccountRewardsPage: NextPage = () => {
   return (
     <Layout seo={{ title: 'Rewards' }}>
       <AccountReferrals />
-      {loyaltyCard && <AccountLoyaltyCard loyaltyCard={loyaltyCard} />}
+      <AccountLoyaltyCard loyaltyCard={loyaltyCard} />
     </Layout>
   );
 };


### PR DESCRIPTION
### Screenshots

![Screen Shot 2022-11-22 at 9 10 16 AM](https://user-images.githubusercontent.com/211047/203379028-a54009e1-5cdb-4949-a685-41c31ee6bc15.png)

### Test Plan (Steps to test):

1. Hey something cool we can do is use our new branch feature to test this!
2. Pull down this penny branch locally
3. Open up the takeshape project at https://app.takeshape.io/project/06ccc3dc-a9da-4f5b-9142-5a104db52ee3 and create a branch to work with. Copy the branch api url from the dashboard
4. Temporarily edit your `.env.local` file and replace the value for `NEXT_PUBLIC_TAKESHAPE_API_URL` with your branch api url
5. In the takeshape app (make sure you're still on your branch) go to the json editor and break your API on your branch so the schema is valid but the `getMyLoyaltyCard` query will fail. For example, I changed `"serialize": {"template": "v1/loyalties/{campaignId}/members"}` to `"serialize": {"template": "v1/loyalties/{campaignId}/membersFFFF"}`
6. `npm run dev` to run the app. Sign in and navigate to the rewards page. Verify you get a nice error message.

### Checklist:

- [x] Create a Test Plan
- [x] Changes Communicated (in commits or above)
- [x] ~Docs Updated~
- [x] ~Storybook Updated~