### PR TITLE
Add support for discount code in url param

### DIFF
--- a/src/features/Cart/Cart.stories.tsx
+++ b/src/features/Cart/Cart.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { cartItemsAtom, isCartOpenAtom } from 'features/Cart/store';
+import { cartDiscountCodeAtom, cartItemsAtom, isCartOpenAtom } from 'features/Cart/store';
 import { currencyAtom } from 'store';
 import { Cart } from './Cart';
 import fixtures from './Cart.fixtures.json';
@@ -39,6 +39,24 @@ WithRecurringAndOneTime.parameters = {
       isCartOpen: true,
       cartItems: [...fixtures.cartItems, { ...fixtures.cartItems[1], interval: 'none', intervalCount: 0 }],
       currency: 'USD'
+    }
+  }
+};
+
+export const WithDiscountCode = Template.bind({});
+WithDiscountCode.parameters = {
+  jotai: {
+    atoms: {
+      isCartOpen: isCartOpenAtom,
+      cartItems: cartItemsAtom,
+      currency: currencyAtom,
+      discountCode: cartDiscountCodeAtom
+    },
+    values: {
+      isCartOpen: true,
+      cartItems: [...fixtures.cartItems],
+      currency: 'USD',
+      discountCode: 'FOOD'
     }
   }
 };

--- a/src/features/Cart/Cart.tsx
+++ b/src/features/Cart/Cart.tsx
@@ -2,6 +2,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import PageLoader from 'components/PageLoader';
 import { isStorybook } from 'config';
+import { CartDiscountCode } from 'features/Cart/components/DiscountCode';
 import { useAtom, useAtomValue } from 'jotai';
 import { Fragment } from 'react';
 import { CartItem } from './components/CartItem';
@@ -65,6 +66,8 @@ export const Cart = () => {
                         </div>
                       </div>
 
+                      <CartDiscountCode />
+
                       <div className="mt-8">
                         {items.length ? (
                           <div className="flow-root">
@@ -85,6 +88,7 @@ export const Cart = () => {
                     <div className="border-t border-body-200 py-6 px-4 sm:px-6">
                       <CartSubtotal />
                       <p className="mt-0.5 text-sm text-body-500">Shipping and taxes calculated at checkout.</p>
+
                       <div className="mt-6">
                         <CartCheckout />
                       </div>

--- a/src/features/Cart/components/Checkout.tsx
+++ b/src/features/Cart/components/Checkout.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect } from 'react';
 import { CartCreateMutationResponse, CartCreateMutationVariables } from 'types/storefront';
 import { useStorefrontMutation } from 'utils/storefront';
 import { CartCreateMutation } from '../queries.storefront';
-import { cartItemsAtom, cartQuantityAtom, isCartCheckingOutAtom } from '../store';
+import { cartDiscountCodeAtom, cartItemsAtom, cartQuantityAtom, isCartCheckingOutAtom } from '../store';
 import { getCartVariables } from '../utils';
 
 export const CartCheckout = () => {
@@ -18,6 +18,7 @@ export const CartCheckout = () => {
   const setIsCartCheckingOut = useSetAtom(isCartCheckingOutAtom);
   const quantity = useAtomValue(cartQuantityAtom);
   const items = useAtomValue(cartItemsAtom);
+  const discountCode = useAtomValue(cartDiscountCodeAtom);
 
   const [setCartMutation, { data }] = useStorefrontMutation<CartCreateMutationResponse, CartCreateMutationVariables>(
     CartCreateMutation
@@ -31,9 +32,9 @@ export const CartCheckout = () => {
 
     setIsCartCheckingOut(true);
     setCartMutation({
-      variables: getCartVariables(items, session)
+      variables: getCartVariables(items, session, discountCode)
     });
-  }, [session, setIsCartCheckingOut, setCartMutation, items, push]);
+  }, [session, setIsCartCheckingOut, setCartMutation, items, discountCode, push]);
 
   useEffect(() => {
     const checkoutUrl = getCheckoutUrl(data);

--- a/src/features/Cart/components/DiscountCode.tsx
+++ b/src/features/Cart/components/DiscountCode.tsx
@@ -1,0 +1,28 @@
+import { Disclosure } from '@headlessui/react';
+import { TagIcon } from '@heroicons/react/24/solid';
+import { cartDiscountCodeAtom } from 'features/Cart/store';
+import { useAtomValue } from 'jotai';
+
+export const CartDiscountCode = () => {
+  const discountCode = useAtomValue(cartDiscountCodeAtom);
+
+  if (!discountCode) {
+    return null;
+  }
+
+  return (
+    <Disclosure>
+      <Disclosure.Button className="w-full mt-8 bg-accent-100 rounded-md border border-body-200 p-2">
+        <div className="w-full flex items-center align-middle text-sm font-bold text-accent-800 gap-1">
+          <TagIcon className="h-4 w-4" aria-hidden="true" />
+          <span className="font-mono">{discountCode}</span>
+        </div>
+        <Disclosure.Panel>
+          <p className="p-1 text-left mt-1 text-sm text-body-500">
+            A discount code has been added to your cart and will be applied at checkout.
+          </p>
+        </Disclosure.Panel>
+      </Disclosure.Button>
+    </Disclosure>
+  );
+};

--- a/src/features/Cart/store.ts
+++ b/src/features/Cart/store.ts
@@ -7,6 +7,9 @@ import { AddToCartInput, CartItem, CartItemAttribute } from './types';
 export const isCartOpenAtom = atom(false);
 export const isCartCheckingOutAtom = atom(false);
 
+/* Discounts */
+export const cartDiscountCodeAtom = atomWithStorage<string | null>('discountCode', null);
+
 /* Cart Items */
 export const cartItemsAtom = atomWithStorage<CartItem[]>(cartLocalStorageKey, []);
 export const cartItemAtomsAtom = splitAtom(cartItemsAtom);

--- a/src/features/Cart/utils.ts
+++ b/src/features/Cart/utils.ts
@@ -3,7 +3,7 @@ import { Session } from 'next-auth';
 import { ProductPriceOption } from 'types/product';
 import { CartCreateMutationVariables, CartLineInput } from 'types/storefront';
 
-export const getCartVariables = (items: CartItem[], session: Session | null) => {
+export const getCartVariables = (items: CartItem[], session: Session | null, discountCode: string | null) => {
   const createCartVariables: CartCreateMutationVariables = {
     input: {
       attributes: [
@@ -22,6 +22,10 @@ export const getCartVariables = (items: CartItem[], session: Session | null) => 
       )
     }
   };
+
+  if (discountCode) {
+    createCartVariables.input.discountCodes = [discountCode];
+  }
 
   if (session?.user?.shopifyCustomerAccessToken) {
     createCartVariables.input.buyerIdentity = {

--- a/src/features/Notification/Notification.tsx
+++ b/src/features/Notification/Notification.tsx
@@ -58,8 +58,8 @@ export const Notification = () => {
                     <StatusIcon status={status} size={6} />
                   </div>
                   <div className="ml-3 w-0 flex-1 pt-0.5">
-                    <p className="text-sm font-medium text-body-900">{title}</p>
-                    <p className="mt-1 text-sm text-body-500">{body}</p>
+                    <p className="text-sm font-medium text-body-900" dangerouslySetInnerHTML={{ __html: title }} />
+                    <p className="mt-1 text-sm text-body-500" dangerouslySetInnerHTML={{ __html: body }} />
                   </div>
                   <div className="ml-4 flex-shrink-0 flex">
                     <button

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function getRedirect(searchParams: URLSearchParams) {
+  const redirect = searchParams.get('redirect');
+  if (redirect) {
+    return redirect
+      .split('/')
+      .filter((x) => x)
+      .join('/');
+  }
+  return '';
+}
+
+function getDiscount(pathname: string) {
+  return new URLSearchParams([['discount', pathname.split('/')[2]]]);
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+  const discount = getDiscount(pathname);
+  const redirect = getRedirect(searchParams);
+  return NextResponse.redirect(new URL(`/${redirect}?${discount.toString()}`, request.url));
+}
+
+export const config = {
+  matcher: '/discount/:path*'
+};

--- a/src/pages/_checkout.tsx
+++ b/src/pages/_checkout.tsx
@@ -1,6 +1,6 @@
 import PageLoader from 'components/PageLoader';
 import { CartCreateMutation } from 'features/Cart/queries.storefront';
-import { cartItemsAtom } from 'features/Cart/store';
+import { cartDiscountCodeAtom, cartItemsAtom } from 'features/Cart/store';
 import { getCheckoutUrl } from 'features/Cart/transforms';
 import { getCartVariables } from 'features/Cart/utils';
 import { useAtomValue } from 'jotai';
@@ -14,6 +14,7 @@ import { useStorefrontMutation } from 'utils/storefront';
 const _CheckoutPage: NextPage = () => {
   const { data: session } = useSession();
   const cartItems = useAtomValue(cartItemsAtom);
+  const discountCode = useAtomValue(cartDiscountCodeAtom);
 
   const [setCartMutation, { data }] = useStorefrontMutation<CartCreateMutationResponse, CartCreateMutationVariables>(
     CartCreateMutation
@@ -23,10 +24,10 @@ const _CheckoutPage: NextPage = () => {
     if (session) {
       setCartMutation({
         mutation: CartCreateMutation,
-        variables: getCartVariables(cartItems, session)
+        variables: getCartVariables(cartItems, session, discountCode)
       });
     }
-  }, [session, setCartMutation, cartItems]);
+  }, [session, setCartMutation, cartItems, discountCode]);
 
   useEffect(() => {
     const checkoutUrl = getCheckoutUrl(data);


### PR DESCRIPTION
### Screenshots

<img width="445" alt="Screenshot 2023-02-03 at 17 05 36" src="https://user-images.githubusercontent.com/277401/216719823-b43b7a54-d1d8-423a-9557-fc1462d1238d.png">

### Test Plan (Steps to test):

1. Go to the path `/discount/food?redirect=collections/men`
1. You should end up on the men's collection, and see a notice that the code was added.
1. Open your cart, you should see the code there. Click it and expand to see the descriptive text.
2. Add an item and checkout. The code `FOOD` has been set up to work. You should see it applied.
3. You can do above with `?discount=food` as well, it's the same mechanism.
