### PR TITLE
E2E tests for registration

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -4,6 +4,7 @@ import { ShoppingCart } from './page-objects/shopping-cart';
 import { ProductPage } from './page-objects/product-page';
 import { ContactPage } from './page-objects/contact-page';
 import { SignInPage } from './page-objects/sign-in-page';
+import { SignUpPage } from './page-objects/sign-up-page';
 
 export const test = baseTest.extend<{
   collectionsPage: CollectionsPage;
@@ -11,6 +12,7 @@ export const test = baseTest.extend<{
   productPage: ProductPage;
   contactPage: ContactPage;
   signInPage: SignInPage;
+  signUpPage: SignUpPage;
 }>({
   collectionsPage: async ({ page }, use) => {
     await use(new CollectionsPage(page));
@@ -26,5 +28,8 @@ export const test = baseTest.extend<{
   },
   signInPage: async ({ page }, use) => {
     await use(new SignInPage(page));
+  },
+  signUpPage: async ({ page }, use) => {
+    await use(new SignUpPage(page));
   }
 });

--- a/e2e/page-objects/sign-up-page.ts
+++ b/e2e/page-objects/sign-up-page.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+
+export class SignUpPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  emailInput = () => this.page.locator('#email');
+  passwordInput = () => this.page.locator('#password');
+  passwordConfirmInput = () => this.page.locator('#passwordConfirm');
+  signUpButton = () => this.page.getByRole('button', { name: 'Sign up', exact: true });
+}

--- a/e2e/page-objects/sign-up-page.ts
+++ b/e2e/page-objects/sign-up-page.ts
@@ -11,4 +11,5 @@ export class SignUpPage {
   passwordInput = () => this.page.locator('#password');
   passwordConfirmInput = () => this.page.locator('#passwordConfirm');
   signUpButton = () => this.page.getByRole('button', { name: 'Sign up', exact: true });
+  createAnAccountNavBtn = () => this.page.getByText('Create an account');
 }

--- a/e2e/page-objects/sign-up-page.ts
+++ b/e2e/page-objects/sign-up-page.ts
@@ -12,4 +12,5 @@ export class SignUpPage {
   passwordConfirmInput = () => this.page.locator('#passwordConfirm');
   signUpButton = () => this.page.getByRole('button', { name: 'Sign up', exact: true });
   createAnAccountNavBtn = () => this.page.getByText('Create an account');
+  signInButton = () => this.page.locator('a', { hasText: 'Sign in' });
 }

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../fixtures';
 import { expect } from 'playwright/test';
-import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, SIGN_UP_PAGE_ENDPOINT } from '../constants';
+import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, SIGN_IN_PAGE_ENDPOINT, SIGN_UP_PAGE_ENDPOINT } from '../constants';
 import { getPassword, getValidEmail } from '../fake-data-generation';
 
 test.describe('Create an account', () => {
@@ -30,5 +30,12 @@ test.describe('Create an account', () => {
     await signUpPage.passwordConfirmInput().fill('passworddoesntmatch');
     await signUpPage.signUpButton().click();
     await expect(page.getByText('The passwords do not match')).toBeVisible();
+  });
+
+  test('Verify user can navigate to the Sign In page', async ({ page, signUpPage }) => {
+    await expect(page.getByText('Already have an account?')).toBeVisible();
+    await signUpPage.signInButton().click();
+    await page.waitForTimeout(1000);
+    expect(page.url()).toContain(SIGN_IN_PAGE_ENDPOINT);
   });
 });

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'playwright/test';
 import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, SIGN_IN_PAGE_ENDPOINT, SIGN_UP_PAGE_ENDPOINT } from '../constants';
 import { getPassword, getValidEmail } from '../fake-data-generation';
 
-test.describe('Create an account', () => {
+test.describe('Registration form', () => {
   test.beforeEach('Navigate to the Sign up page', async ({ page, signUpPage }) => {
     await page.goto(HOMEPAGE_ENDPOINT);
     await signUpPage.createAnAccountNavBtn().click();

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -1,13 +1,13 @@
 import { test } from '../fixtures';
 import { expect } from 'playwright/test';
-import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, USER_PASSWORD, VALID_EMAIL } from '../constants';
+import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, PASSWORD, SIGN_UP_PAGE_ENDPOINT, VALID_EMAIL } from '../constants';
 
 test.describe('Create an account', () => {
-  test.beforeEach('Navigate to the sign up page', async ({ page }) => {
+  test.beforeEach('Navigate to the Sign up page', async ({ page, signUpPage }) => {
     await page.goto(HOMEPAGE_ENDPOINT);
-    await page.getByText('Create an account').click();
+    await signUpPage.createAnAccountNavBtn().click();
     await expect(page.getByText('Create your account')).toBeVisible();
-    expect(page.url()).toContain('auth/create');
+    expect(page.url()).toContain(SIGN_UP_PAGE_ENDPOINT);
   });
 
   test('Verify red messages appear if required fields are not filled in', async ({ page, signUpPage }) => {
@@ -17,15 +17,15 @@ test.describe('Create an account', () => {
 
   test('Cannot register a new user using invalid email', async ({ page, signUpPage }) => {
     await signUpPage.emailInput().fill(INVALID_EMAIL);
-    await signUpPage.passwordInput().fill(USER_PASSWORD);
-    await signUpPage.passwordConfirmInput().fill(USER_PASSWORD);
+    await signUpPage.passwordInput().fill(PASSWORD);
+    await signUpPage.passwordConfirmInput().fill(PASSWORD);
     await signUpPage.signUpButton().click();
     await expect(page.getByText('Please enter a valid email')).toBeVisible();
   });
 
   test("Cannot register a new user if passwords don't match", async ({ page, signUpPage }) => {
     await signUpPage.emailInput().fill(VALID_EMAIL);
-    await signUpPage.passwordInput().fill(USER_PASSWORD);
+    await signUpPage.passwordInput().fill(PASSWORD);
     await signUpPage.passwordConfirmInput().fill('passworddoesntmatch');
     await signUpPage.signUpButton().click();
     await expect(page.getByText('The passwords do not match')).toBeVisible();

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '../fixtures';
 import { expect } from 'playwright/test';
-import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, PASSWORD, SIGN_UP_PAGE_ENDPOINT, VALID_EMAIL } from '../constants';
+import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, SIGN_UP_PAGE_ENDPOINT } from '../constants';
+import { getPassword, getValidEmail } from '../fake-data-generation';
 
 test.describe('Create an account', () => {
   test.beforeEach('Navigate to the Sign up page', async ({ page, signUpPage }) => {
@@ -17,15 +18,15 @@ test.describe('Create an account', () => {
 
   test('Cannot register a new user using invalid email', async ({ page, signUpPage }) => {
     await signUpPage.emailInput().fill(INVALID_EMAIL);
-    await signUpPage.passwordInput().fill(PASSWORD);
-    await signUpPage.passwordConfirmInput().fill(PASSWORD);
+    await signUpPage.passwordInput().fill(getPassword());
+    await signUpPage.passwordConfirmInput().fill(getPassword());
     await signUpPage.signUpButton().click();
     await expect(page.getByText('Please enter a valid email')).toBeVisible();
   });
 
   test("Cannot register a new user if passwords don't match", async ({ page, signUpPage }) => {
-    await signUpPage.emailInput().fill(VALID_EMAIL);
-    await signUpPage.passwordInput().fill(PASSWORD);
+    await signUpPage.emailInput().fill(getValidEmail());
+    await signUpPage.passwordInput().fill(getPassword());
     await signUpPage.passwordConfirmInput().fill('passworddoesntmatch');
     await signUpPage.signUpButton().click();
     await expect(page.getByText('The passwords do not match')).toBeVisible();

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -17,9 +17,11 @@ test.describe('Registration form', () => {
   });
 
   test('Cannot register a new user using invalid email', async ({ page, signUpPage }) => {
+    const password = getPassword();
+
     await signUpPage.emailInput().fill(INVALID_EMAIL);
-    await signUpPage.passwordInput().fill(getPassword());
-    await signUpPage.passwordConfirmInput().fill(getPassword());
+    await signUpPage.passwordInput().fill(password);
+    await signUpPage.passwordConfirmInput().fill(password);
     await signUpPage.signUpButton().click();
     await expect(page.getByText('Please enter a valid email')).toBeVisible();
   });

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -1,0 +1,33 @@
+import { test } from '../fixtures';
+import { expect } from 'playwright/test';
+import { HOMEPAGE_ENDPOINT, INVALID_EMAIL, USER_PASSWORD, VALID_EMAIL } from '../constants';
+
+test.describe('Create an account', () => {
+  test.beforeEach('Navigate to the sign up page', async ({ page }) => {
+    await page.goto(HOMEPAGE_ENDPOINT);
+    await page.getByText('Create an account').click();
+    await expect(page.getByText('Create your account')).toBeVisible();
+    expect(page.url()).toContain('auth/create');
+  });
+
+  test('Verify red messages appear if required fields are not filled in', async ({ page, signUpPage }) => {
+    await signUpPage.signUpButton().click();
+    await expect(page.getByText('This field is required')).toHaveCount(3);
+  });
+
+  test('Cannot register a new user using invalid email', async ({ page, signUpPage }) => {
+    await signUpPage.emailInput().fill(INVALID_EMAIL);
+    await signUpPage.passwordInput().fill(USER_PASSWORD);
+    await signUpPage.passwordConfirmInput().fill(USER_PASSWORD);
+    await signUpPage.signUpButton().click();
+    await expect(page.getByText('Please enter a valid email')).toBeVisible();
+  });
+
+  test("Cannot register a new user if passwords don't match", async ({ page, signUpPage }) => {
+    await signUpPage.emailInput().fill(VALID_EMAIL);
+    await signUpPage.passwordInput().fill(USER_PASSWORD);
+    await signUpPage.passwordConfirmInput().fill('passworddoesntmatch');
+    await signUpPage.signUpButton().click();
+    await expect(page.getByText('The passwords do not match')).toBeVisible();
+  });
+});


### PR DESCRIPTION
- added SignUpPage class with locators;
- created negative tests for registration;

> If you don't want to invoke CI, put `[skip ci]` in the commit message

### Screenshots

### Test Plan (Steps to test):

1. 
1. 
1. 

### Checklist:

- [ ] Create a Test Plan
- [ ] Changes Communicated (in commits or above)
- [ ] Docs Updated
- [ ] Storybook Updated